### PR TITLE
feat: Add basic Login and Signup pages

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -9,6 +9,8 @@ import SearchResultsPage from "pages/search-results-page";
 import AuthorProfilePage from "pages/author-profile-page";
 import ArticleDetailPage from "pages/article-detail-page";
 import NotFound from "pages/NotFound";
+import LoginPage from "pages/login-page"; // Added import
+import SignupPage from "pages/signup-page"; // Added import
 
 const Routes = () => {
   return (
@@ -23,6 +25,12 @@ const Routes = () => {
           <Route path="/search-results-page" element={<SearchResultsPage />} />
           <Route path="/author-profile-page" element={<AuthorProfilePage />} />
           <Route path="/article-detail-page" element={<ArticleDetailPage />} />
+
+          {/* Added Routes */}
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+
+          {/* NotFound Route should be last */}
           <Route path="*" element={<NotFound />} />
         </RouterRoutes>
       </ErrorBoundary>

--- a/src/components/ui/Header.jsx
+++ b/src/components/ui/Header.jsx
@@ -17,6 +17,12 @@ const Header = () => {
     { label: 'About', path: '/about-contact-page', icon: 'Info' },
   ];
 
+  // New auth navigation items
+  const authNavigationItems = [
+    { label: 'Login', path: '/login', icon: 'LogIn' }, // Added LogIn icon
+    { label: 'Sign Up', path: '/signup', icon: 'UserPlus' } // Added UserPlus icon
+  ];
+
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
   };
@@ -103,7 +109,7 @@ const Header = () => {
             </Link>
 
             {/* Desktop Navigation */}
-            <nav className="hidden lg:flex items-center space-x-8">
+            <nav className="hidden lg:flex items-center space-x-1"> {/* Reduced space-x slightly */}
               {navigationItems.map((item) => (
                 <Link
                   key={item.path}
@@ -116,11 +122,24 @@ const Header = () => {
                   {item.label}
                 </Link>
               ))}
+               {/* Desktop Auth Links - Separated for clarity and potential different styling/positioning */}
+              <div className="ml-4 flex items-center space-x-1">
+                {authNavigationItems.map((item) => (
+                  <Link
+                    key={item.path}
+                    to={item.path}
+                    className={`font-heading font-medium nav-transition px-3 py-2 rounded-button ${
+                      isActivePath(item.path)
+                        ? 'text-accent bg-accent/10' :'text-text-primary hover:text-accent hover:bg-accent/5'
+                    }`}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
             </nav>
 
-            {/* Desktop Search & Mobile Controls */}
-            <div className="flex items-center space-x-4">
-              {/* Desktop Search */}
+            <div className="flex items-center space-x-2 sm:space-x-4"> {/* Adjusted spacing for mobile too */}
               <div className="hidden lg:block relative">
                 {isSearchOpen ? (
                   <form onSubmit={handleSearchSubmit} className="flex items-center">
@@ -131,7 +150,7 @@ const Header = () => {
                         value={searchQuery}
                         onChange={handleSearchChange}
                         placeholder="Search articles..."
-                        className="w-64 pl-10 pr-4 py-2 border border-border rounded-button focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent nav-transition"
+                        className="w-48 xl:w-64 pl-10 pr-4 py-2 border border-border rounded-button focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent nav-transition" // Adjusted width
                       />
                       <Icon 
                         name="Search" 
@@ -239,7 +258,7 @@ const Header = () => {
           </div>
 
           {/* Mobile Navigation Items */}
-          <nav className="flex-1 px-6 py-4">
+          <nav className="flex-1 px-6 py-4 overflow-y-auto"> {/* Added overflow-y-auto */}
             <ul className="space-y-2">
               {navigationItems.map((item) => (
                 <li key={item.path}>
@@ -251,12 +270,32 @@ const Header = () => {
                         ? 'text-accent bg-accent/10' :'text-text-primary hover:text-accent hover:bg-accent/5'
                     }`}
                   >
-                    <Icon name={item.icon} size={20} />
+                    <Icon name={item.icon} size={20} className={isActivePath(item.path) ? 'text-accent' : 'text-text-secondary'} />
                     <span className="font-heading font-medium">{item.label}</span>
                   </Link>
                 </li>
               ))}
             </ul>
+            {/* Auth Links in Mobile Menu */}
+            <div className="mt-6 pt-6 border-t border-border">
+              <ul className="space-y-2">
+                {authNavigationItems.map((item) => (
+                  <li key={item.path}>
+                    <Link
+                      to={item.path}
+                      onClick={closeMobileMenu}
+                      className={`flex items-center space-x-3 px-4 py-3 rounded-button nav-transition ${
+                        isActivePath(item.path)
+                          ? 'text-accent bg-accent/10' :'text-text-primary hover:text-accent hover:bg-accent/5'
+                      }`}
+                    >
+                      <Icon name={item.icon} size={20} className={isActivePath(item.path) ? 'text-accent' : 'text-text-secondary'} />
+                      <span className="font-heading font-medium">{item.label}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </nav>
         </div>
       </div>

--- a/src/pages/login-page/index.jsx
+++ b/src/pages/login-page/index.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { Link, useNavigate } from 'react-router-dom';
+import Icon from 'components/AppIcon'; // Assuming AppIcon can render a generic icon
+
+const LoginPage = () => {
+  const { register, handleSubmit, formState: { errors } } = useForm();
+  const navigate = useNavigate();
+
+  const onSubmit = (data) => {
+    console.log('Login data:', data);
+    // In a real app, you'd call your login API here
+    // For now, let's navigate to the home page on successful "login"
+    alert('Login successful (mock)! Redirecting to home page.');
+    navigate('/'); // Navigate to home page
+  };
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col justify-center items-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="flex justify-center mb-6">
+          {/* You might want to place a logo here, using AppIcon or AppImage */}
+          <Icon name="LogIn" size={48} className="text-accent" />
+        </div>
+        <h2 className="mt-6 text-center text-3xl font-heading font-bold text-text-primary">
+          Sign in to your account
+        </h2>
+        <p className="mt-2 text-center text-sm text-text-secondary">
+          Or{' '}
+          <Link to="/signup" className="font-medium text-accent hover:text-accent/80 nav-transition">
+            create a new account
+          </Link>
+        </p>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-surface py-8 px-4 shadow-content rounded-card sm:px-10">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-text-primary">
+                Email address
+              </label>
+              <div className="mt-1">
+                <input
+                  id="email"
+                  type="email"
+                  autoComplete="email"
+                  {...register('email', {
+                    required: 'Email is required',
+                    pattern: {
+                      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                      message: 'Invalid email address'
+                    }
+                  })}
+                  className={`appearance-none block w-full px-3 py-2 border ${errors.email ? 'border-error' : 'border-border'} rounded-button shadow-sm placeholder-text-secondary focus:outline-none focus:ring-accent focus:border-accent sm:text-sm nav-transition`}
+                />
+              </div>
+              {errors.email && <p className="mt-2 text-sm text-error">{errors.email.message}</p>}
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between">
+                <label htmlFor="password" className="block text-sm font-medium text-text-primary">
+                  Password
+                </label>
+                <div className="text-sm">
+                  <a href="#" className="font-medium text-accent hover:text-accent/80 nav-transition">
+                    Forgot your password?
+                  </a>
+                </div>
+              </div>
+              <div className="mt-1">
+                <input
+                  id="password"
+                  type="password"
+                  autoComplete="current-password"
+                  {...register('password', {
+                    required: 'Password is required'
+                  })}
+                  className={`appearance-none block w-full px-3 py-2 border ${errors.password ? 'border-error' : 'border-border'} rounded-button shadow-sm placeholder-text-secondary focus:outline-none focus:ring-accent focus:border-accent sm:text-sm nav-transition`}
+                />
+              </div>
+              {errors.password && <p className="mt-2 text-sm text-error">{errors.password.message}</p>}
+            </div>
+
+            <div>
+              <button
+                type="submit"
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-button shadow-sm text-sm font-medium text-white bg-accent hover:bg-accent/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent nav-transition"
+              >
+                Sign in
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/signup-page/index.jsx
+++ b/src/pages/signup-page/index.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { Link, useNavigate } from 'react-router-dom';
+import Icon from 'components/AppIcon'; // Assuming AppIcon can render a generic icon or specific ones
+
+const SignupPage = () => {
+  const { register, handleSubmit, formState: { errors }, watch } = useForm();
+  const navigate = useNavigate();
+  const password = watch('password');
+
+  const onSubmit = (data) => {
+    console.log('Signup data:', data);
+    // In a real app, you'd call your signup API here
+    // For now, let's navigate to login page on successful "signup"
+    alert('Signup successful (mock)! Redirecting to login.');
+    navigate('/login');
+  };
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col justify-center items-center py-12 sm:px-6 lg:px-8">
+      <div className="sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="flex justify-center mb-6">
+          {/* You might want to place a logo here, using AppIcon or AppImage */}
+          <Icon name="Users" size={48} className="text-accent" />
+        </div>
+        <h2 className="mt-6 text-center text-3xl font-heading font-bold text-text-primary">
+          Create your account
+        </h2>
+        <p className="mt-2 text-center text-sm text-text-secondary">
+          Or{' '}
+          <Link to="/login" className="font-medium text-accent hover:text-accent/80 nav-transition">
+            sign in to your existing account
+          </Link>
+        </p>
+      </div>
+
+      <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+        <div className="bg-surface py-8 px-4 shadow-content rounded-card sm:px-10">
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-text-primary">
+                Email address
+              </label>
+              <div className="mt-1">
+                <input
+                  id="email"
+                  type="email"
+                  autoComplete="email"
+                  {...register('email', {
+                    required: 'Email is required',
+                    pattern: {
+                      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                      message: 'Invalid email address'
+                    }
+                  })}
+                  className={`appearance-none block w-full px-3 py-2 border ${errors.email ? 'border-error' : 'border-border'} rounded-button shadow-sm placeholder-text-secondary focus:outline-none focus:ring-accent focus:border-accent sm:text-sm nav-transition`}
+                />
+              </div>
+              {errors.email && <p className="mt-2 text-sm text-error">{errors.email.message}</p>}
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-text-primary">
+                Password
+              </label>
+              <div className="mt-1">
+                <input
+                  id="password"
+                  type="password"
+                  autoComplete="new-password"
+                  {...register('password', {
+                    required: 'Password is required',
+                    minLength: {
+                      value: 8,
+                      message: 'Password must be at least 8 characters'
+                    }
+                  })}
+                  className={`appearance-none block w-full px-3 py-2 border ${errors.password ? 'border-error' : 'border-border'} rounded-button shadow-sm placeholder-text-secondary focus:outline-none focus:ring-accent focus:border-accent sm:text-sm nav-transition`}
+                />
+              </div>
+              {errors.password && <p className="mt-2 text-sm text-error">{errors.password.message}</p>}
+            </div>
+
+            <div>
+              <label htmlFor="confirmPassword" className="block text-sm font-medium text-text-primary">
+                Confirm Password
+              </label>
+              <div className="mt-1">
+                <input
+                  id="confirmPassword"
+                  type="password"
+                  autoComplete="new-password"
+                  {...register('confirmPassword', {
+                    required: 'Please confirm your password',
+                    validate: value => value === password || 'Passwords do not match'
+                  })}
+                  className={`appearance-none block w-full px-3 py-2 border ${errors.confirmPassword ? 'border-error' : 'border-border'} rounded-button shadow-sm placeholder-text-secondary focus:outline-none focus:ring-accent focus:border-accent sm:text-sm nav-transition`}
+                />
+              </div>
+              {errors.confirmPassword && <p className="mt-2 text-sm text-error">{errors.confirmPassword.message}</p>}
+            </div>
+
+            <div>
+              <button
+                type="submit"
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-button shadow-sm text-sm font-medium text-white bg-accent hover:bg-accent/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent nav-transition"
+              >
+                Sign up
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SignupPage;


### PR DESCRIPTION
This commit introduces initial Login and Signup pages to the frontend.

Key changes include:
- Creation of `src/pages/signup-page/index.jsx` with a registration form (Email, Password, Confirm Password) using `react-hook-form` for validation.
- Creation of `src/pages/login-page/index.jsx` with a login form (Email, Password) using `react-hook-form` for validation.
- Both pages are styled with Tailwind CSS, consistent with the existing application theme, and include links to each other.
- Updated `src/Routes.jsx` to include routes for `/login` and `/signup`.
- Added "Login" and "Sign Up" navigation links to the main application header (`src/components/ui/Header.jsx`) for both desktop and mobile views.

These pages currently feature mock submissions (console logging and navigation) and do not involve actual API calls for authentication, which will be handled in subsequent work.